### PR TITLE
fix: Condition where server fails to start is not handled properly

### DIFF
--- a/runner-package/runner.ts
+++ b/runner-package/runner.ts
@@ -915,21 +915,23 @@ export async function runTestSession(): Promise<void> {
         }
 
         // Wait for the server to exit gracefully
-        await new Promise<void>((resolve) => {
-            const timeout = setTimeout(() => {
-                console.log('[WARNING] Server did not stop gracefully, forcing shutdown...');
-                serverProcess.kill();
-                resolve();
-            }, 30000); // 30 second timeout
+        if (serverProcess.exitCode === null) {
+            await new Promise<void>((resolve) => {
+                const timeout = setTimeout(() => {
+                    console.log('[WARNING] Server did not stop gracefully, forcing shutdown...');
+                    serverProcess.kill();
+                    resolve();
+                }, 30000); // 30 second timeout
 
-            serverProcess.once('exit', (code) => {
-                clearTimeout(timeout);
-                if (code !== 0) {
-                    console.log(`[WARNING] Server exited with code: ${code}`);
-                }
-                resolve();
+                serverProcess.once('exit', (code) => {
+                    clearTimeout(timeout);
+                    if (code !== 0) {
+                        console.log(`[WARNING] Server exited with code: ${code}`);
+                    }
+                    resolve();
+                });
             });
-        });
+        }
 
         // Clean up all listeners and streams
         serverProcess.removeAllListeners();


### PR DESCRIPTION
## Summary

Fixes issue where gradle task hangs when server fails to start.

## Changes

- Improved error handling during server startup.

## Testing

Verified locally.

Fixes Drownek/paper-e2e-test#8